### PR TITLE
Add record field retention helpers

### DIFF
--- a/src/string_record.rs
+++ b/src/string_record.rs
@@ -430,14 +430,46 @@ impl StringRecord {
         if length == 0 {
             return;
         }
-        // TODO: We could likely do this in place, but for now, we allocate.
-        let mut trimmed =
-            StringRecord::with_capacity(self.as_slice().len(), self.len());
-        trimmed.set_position(self.position().cloned());
-        for field in &*self {
-            trimmed.push_field(field.trim());
+        let mut write = 0;
+        let mut prev_end = 0;
+        let (fields, ends) = self.0.as_parts();
+        for i in 0..length {
+            let end = ends[i];
+            let start = prev_end;
+            prev_end = end;
+            let field =
+                unsafe { str::from_utf8_unchecked(&fields[start..end]) };
+            let (trim_start, trim_end) = trim_unicode_range(field);
+            let trimmed_start = start + trim_start;
+            let trimmed_end = start + trim_end;
+            fields.copy_within(trimmed_start..trimmed_end, write);
+            write += trimmed_end - trimmed_start;
+            ends[i] = write;
         }
-        *self = trimmed;
+    }
+
+    /// Retain only the fields specified by the predicate.
+    ///
+    /// The predicate is applied in field order, and only fields for which the
+    /// predicate returns true are kept.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use csv::StringRecord;
+    ///
+    /// let mut record = StringRecord::from(vec!["a", "", "b", ""]);
+    /// record.retain(|field| !field.is_empty());
+    /// assert_eq!(record, vec!["a", "b"]);
+    /// ```
+    pub fn retain<F>(&mut self, mut keep: F)
+    where
+        F: FnMut(&str) -> bool,
+    {
+        self.0.retain(|field| {
+            let field = unsafe { str::from_utf8_unchecked(field) };
+            keep(field)
+        });
     }
 
     /// Add a new field to this record.
@@ -744,6 +776,14 @@ impl<'r> DoubleEndedIterator for StringRecordIter<'r> {
     }
 }
 
+fn trim_unicode_range(field: &str) -> (usize, usize) {
+    let trimmed_start = field.trim_start();
+    let start = field.len() - trimmed_start.len();
+    let trimmed = trimmed_start.trim_end();
+    let end = start + trimmed.len();
+    (start, end)
+}
+
 #[cfg(test)]
 mod tests {
     use crate::string_record::StringRecord;
@@ -813,6 +853,16 @@ mod tests {
         ]);
         rec.trim();
         assert_eq!(rec.get(0), Some(""));
+    }
+
+    #[test]
+    fn retain_fields() {
+        let mut rec = StringRecord::from(vec!["a", "", "b", "", "c"]);
+        rec.retain(|field| !field.is_empty());
+        assert_eq!(rec, vec!["a", "b", "c"]);
+
+        rec.retain(|field| field == "b");
+        assert_eq!(rec, vec!["b"]);
     }
 
     // Check that record equality respects field boundaries.


### PR DESCRIPTION
### Motivation

- Provide an API to filter record fields in-place without reallocating the record buffer via a `retain` method.
- Complement existing in-place trimming behavior so callers can both trim and filter fields efficiently.
- Keep UTF-8 correctness for `StringRecord` while reusing the byte-level representation for performance.

### Description

- Added `pub fn retain<F>(&mut self, keep: F)` to `ByteRecord` that compacts fields in-place by copying kept fields and updating `bounds.len` and `bounds.ends` accordingly.  
- Added `pub fn retain<F>(&mut self, keep: F)` to `StringRecord` which delegates to the underlying byte-level `retain` and converts slices to `&str` with `unsafe { str::from_utf8_unchecked(...) }` for predicate calls.  
- Introduced/used trimming helper functions (`trim_ascii_range` and `trim_unicode_range`) and switched trimming implementations to operate in-place using `copy_within` and write indices.  
- Added unit tests named `retain_fields` to both `src/byte_record.rs` and `src/string_record.rs` to verify retention behavior alongside existing trimming tests.

### Testing

- Added unit tests `retain_fields` in `src/byte_record.rs` and `src/string_record.rs` covering typical retention scenarios.  
- Existing unit tests for `trim` and other record invariants were left intact.  
- No automated test run was executed as part of this change (`cargo test` was not run).  
- CI/build status is not known from this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f9dc942448330a33052f3774da248)