### PR TITLE
Escape backticks in metadata workflow messages

### DIFF
--- a/.github/workflows/metadata-on-merge.yml
+++ b/.github/workflows/metadata-on-merge.yml
@@ -135,9 +135,9 @@ jobs:
             Please update Rust metadata files in this PR (post-merge fixup).
 
             Rules:
-            - Allowlist: `.github/metadata/allowlist.txt` (supports !exclude).
-            - Output path mapping: `/path/to/src/a.rs` -> `/path/to/src/a.metadata.txt`
-            - Prompt: follow `.github/metadata/prompt.txt` exactly.
+            - Allowlist: \`.github/metadata/allowlist.txt\` (supports !exclude).
+            - Output path mapping: \`/path/to/src/a.rs\` -> \`/path/to/src/a.metadata.txt\`
+            - Prompt: follow \`.github/metadata/prompt.txt\` exactly.
             - Added Rust file: create metadata from Rust source + prompt.
             - Modified Rust file: update metadata using Rust source + existing metadata + prompt.
             - Deleted Rust file: delete corresponding .metadata.txt if exists.

--- a/.github/workflows/metadata-on-pr-create.yml
+++ b/.github/workflows/metadata-on-pr-create.yml
@@ -118,9 +118,9 @@ jobs:
             Please update Rust metadata files for this PR.
 
             Rules:
-            - Allowlist: use glob patterns from `.github/metadata/allowlist.txt` (supports !exclude lines).
-            - Output path mapping: `/path/to/src/a.rs` -> `/path/to/src/a.metadata.txt`
-            - Prompt: follow `.github/metadata/prompt.txt` exactly for output structure and style.
+            - Allowlist: use glob patterns from \`.github/metadata/allowlist.txt\` (supports !exclude lines).
+            - Output path mapping: \`/path/to/src/a.rs\` -> \`/path/to/src/a.metadata.txt\`
+            - Prompt: follow \`.github/metadata/prompt.txt\` exactly for output structure and style.
             - Added Rust file: generate metadata from Rust source + prompt.
             - Modified Rust file: update metadata using Rust source + existing metadata + prompt.
             - Deleted Rust file: if corresponding .metadata.txt exists, delete it.


### PR DESCRIPTION
### Motivation
- Prevent JavaScript template literal parsing errors caused by raw Markdown backticks inside GitHub Actions comment bodies.
- Ensure the automated metadata request and post-merge messages render and post correctly when created by the workflows.
- Apply the fix to the metadata comment templates so downstream tooling does not misinterpret message contents.

### Description
- Replace raw Markdown backticks with escaped backticks (`\``) in the comment template lines for `Allowlist`, `Output path mapping`, and `Prompt`.
- Update ` .github/workflows/metadata-on-pr-create.yml` to escape the inline backticks in the posted PR comment body.
- Update ` .github/workflows/metadata-on-merge.yml` to escape the inline backticks in the post-merge comment body.
- No other logic or behavior in the workflows was changed.

### Testing
- This is a workflow-only change and no automated unit or integration tests were executed.
- Changes are limited to message text formatting and do not affect runtime workflow steps.
- Manual verification is implied by the commit but no CI jobs were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960cfae886c8330b78d3bc76ca4d749)