### PR TITLE
Add LLM metadata stubs for allowlisted CSV sources

### DIFF
--- a/.github/metadata/allowlist.txt
+++ b/.github/metadata/allowlist.txt
@@ -5,3 +5,5 @@ crates/**/src/*.rs
 # exclude patterns: ! 로 시작
 !crates/experimental/**
 !crates/**/src/generated/*.rs
+
+# skipped (<100 lines): src/debug.rs

--- a/src/byte_record.metadata.txt
+++ b/src/byte_record.metadata.txt
@@ -1,0 +1,55 @@
+```
+[FILE METADATA]
+high_level_purpose:
+- Implements `ByteRecord`, a CSV row representation that stores raw bytes (including non-UTF-8) plus optional position metadata.
+- Provides low-level field storage, iteration, trimming, and Serde deserialization for byte-oriented CSV workflows.
+
+core_domain_concepts:
+- ByteRecord: row container storing fields contiguously as bytes with explicit bounds.
+- Position: byte/line/record location used for error reporting.
+- Bounds: internal field boundary tracking (end offsets and field count).
+- ByteRecordIter: double-ended iterator over byte slices in a record.
+
+correctness_critical_invariants_and_assumptions:
+- Invariant: `Bounds.len` is the authoritative field count; `bounds.ends()[i]` are monotonically increasing and define field slices within the contiguous `fields` buffer.
+- Invariant: `Position.line` is always >= 1; `byte` and `record` counters are zero-based.
+- Invariant: `ByteRecord::validate` requires each field to be independently valid UTF-8; concatenated fields being valid is insufficient.
+- Assumption: callers that rely on equality compare only field bytes, not position metadata.
+
+lifecycle_and_main_flows:
+- Construction flow: allocate a contiguous byte buffer and bounds, push fields to extend the record, and optionally set position metadata.
+- Conversion flow: `StringRecord::from_byte_record` (via `validate`) or `deserialize` uses record contents plus optional headers.
+- Mutation flow: `trim` creates a new record with trimmed ASCII whitespace, preserving position metadata, then swaps in.
+
+edge_cases_and_tricky_behavior:
+- `trim` uses ASCII whitespace only (not Unicode), and handles empty records without panicking.
+- UTF-8 validation reports the first invalid field and `valid_up_to` within that field; fields are validated independently, which can fail even if the concatenated buffer is valid.
+- `ByteRecord` equality ignores position, so two records with identical fields but different positions compare equal.
+
+concurrency_and_ordering_contracts:
+- None; logic is effectively single-threaded and synchronous.
+
+error_propagation_and_recovery:
+- UTF-8 validation returns a `Utf8Error` with field index and offset; conversion to `StringRecord` wraps this as `FromUtf8Error`.
+- Serde deserialization errors are surfaced via `deserialize_byte_record` and carry the record position when available.
+
+design_and_responsibility_boundaries:
+- `ByteRecord` owns storage and boundary tracking; higher-level parsing/serialization lives in reader/writer modules.
+- Position tracking is optional and only set by readers or manual callers.
+- The record uses `Bounds` to avoid per-field allocations, trading complexity for performance.
+
+likely_bug_hotspots_and_risks:
+- Risk: manual bounds and buffer growth (`expand_fields`/`Bounds::expand`) can introduce off-by-one or overflow issues for extremely large records.
+- Risk: ASCII-only trimming might surprise callers expecting Unicode whitespace trimming.
+
+refactoring_and_extension_notes:
+- Bounds and contiguous storage are tightly coupled; changes must preserve the invariant that slices are valid within the buffer.
+- Any new field-manipulation APIs should preserve position metadata and field boundary correctness.
+
+usage_guidance_for_future_llms:
+- For code review, focus on: bounds updates, trimming behavior, and UTF-8 validation semantics per field.
+- For architectural review, consider: whether new record-level features belong here or in higher-level reader/writer APIs.
+- For adding new features, pay particular attention to: maintaining contiguous buffer invariants and error reporting accuracy.
+- When summarizing for a human, always mention: byte-oriented record storage, optional position tracking, and per-field UTF-8 validation behavior.
+[END FILE METADATA]
+```

--- a/src/cookbook.metadata.txt
+++ b/src/cookbook.metadata.txt
@@ -1,0 +1,42 @@
+```
+[FILE METADATA]
+high_level_purpose:
+- Provides narrative documentation and runnable examples for common CSV reading and writing scenarios.
+- Serves as a curated index of example programs demonstrating the public API.
+
+core_domain_concepts:
+- Example workflows: basic read/write, Serde integration, delimiter configuration, and header handling.
+- User guidance: links and references to example binaries in the `examples` directory.
+
+correctness_critical_invariants_and_assumptions:
+- Assumption: examples reflect the intended public API usage and are kept in sync with actual behavior.
+- Invariant: documentation references example filenames and commands that should remain valid.
+
+lifecycle_and_main_flows:
+- Documentation flow: each section introduces a scenario, presents code, and shows how to run it.
+
+edge_cases_and_tricky_behavior:
+- Examples emphasize error handling via `Result` and `?`, illustrating propagation expectations rather than exhaustive error cases.
+
+concurrency_and_ordering_contracts:
+- None; documentation only.
+
+error_propagation_and_recovery:
+- Examples demonstrate standard error propagation via `Result` and explicit error printing in `main`.
+
+design_and_responsibility_boundaries:
+- This module is purely documentation; it does not implement runtime logic.
+
+likely_bug_hotspots_and_risks:
+- Risk: example code or command lines can drift from actual API behavior, leading to user confusion.
+
+refactoring_and_extension_notes:
+- Keep example lists and headings in sync with actual example files when adding or removing examples.
+
+usage_guidance_for_future_llms:
+- For code review, focus on: accuracy of example code and references to example binaries.
+- For architectural review, consider: whether new features should be illustrated here for user onboarding.
+- For adding new features, pay particular attention to: updating the example list and ensuring instructions remain runnable.
+- When summarizing for a human, always mention: this is documentation with runnable examples for the CSV API.
+[END FILE METADATA]
+```

--- a/src/deserializer.metadata.txt
+++ b/src/deserializer.metadata.txt
@@ -1,0 +1,53 @@
+```
+[FILE METADATA]
+high_level_purpose:
+- Implements Serde deserialization from CSV records (`StringRecord` or `ByteRecord`) into Rust types.
+- Provides a unified deserializer layer with detailed error reporting and optional header-based field mapping.
+
+core_domain_concepts:
+- DeRecord trait: abstraction over string vs byte record access used by the Serde deserializer.
+- DeStringRecord / DeByteRecord: concrete adapters that iterate fields and headers while tracking field index.
+- DeserializeError / DeserializeErrorKind: structured errors that include field index and parse failures.
+- Type inference: `deserialize_any` uses heuristics to infer booleans, integers, floats, or strings/bytes.
+
+correctness_critical_invariants_and_assumptions:
+- Invariant: field index (`field`) increments per field access and is used for error context; errors refer to the most recently accessed field.
+- Invariant: map/struct deserialization requires headers; `MapAccess::next_key_seed` assumes `has_headers()` and asserts it.
+- Assumption: header iteration and field iteration stay in lockstep for map/struct deserialization; mismatches can yield unexpected end-of-row errors.
+
+lifecycle_and_main_flows:
+- Entry: `deserialize_string_record`/`deserialize_byte_record` wraps a record adapter and runs Serde `Deserialize`.
+- Field access: adapters provide `next_field`/`next_header` plus peek capability for sequence termination.
+- Type inference: `deserialize_any` chooses bool → integer → float → string/bytes based on parse success.
+
+edge_cases_and_tricky_behavior:
+- `deserialize_any` on byte records falls back to bytes if UTF-8 decoding fails, but string records always yield UTF-8 strings.
+- Integer parsing supports hexadecimal when the field starts with `0x` (via `from_str_radix`).
+- `UnexpectedEndOfRow` is emitted when a type requests more fields than are present, which can surface for mismatched struct/row lengths.
+
+concurrency_and_ordering_contracts:
+- None; logic is effectively single-threaded and synchronous.
+
+error_propagation_and_recovery:
+- All Serde errors are wrapped in `DeserializeError`, which is then wrapped in `ErrorKind::Deserialize` with record position when available.
+- Parse errors are specialized (`ParseBool`, `ParseInt`, `ParseFloat`, `InvalidUtf8`) to preserve source details.
+
+design_and_responsibility_boundaries:
+- This module is the Serde boundary: it converts record fields into Serde’s `Deserializer` interface while keeping CSV-specific error context.
+- `DeRecord` isolates byte vs string differences to avoid redundant UTF-8 validation for `StringRecord`.
+
+likely_bug_hotspots_and_risks:
+- Risk: reliance on header presence for map/struct deserialization; misuse can lead to assertion failures or unexpected errors.
+- Risk: inference ordering in `deserialize_any` can cause surprising type choices (e.g., numeric-looking strings parsed as numbers).
+
+refactoring_and_extension_notes:
+- Preserve the field index tracking semantics; error context depends on it.
+- Any changes to inference order or parse heuristics should be considered API-affecting for downstream deserialization behavior.
+
+usage_guidance_for_future_llms:
+- For code review, focus on: header handling, field index tracking, and parse error mapping.
+- For architectural review, consider: whether new deserialization behaviors belong in `DeRecord` vs higher-level reader APIs.
+- For adding new features, pay particular attention to: inference ordering and how invalid UTF-8 is surfaced for byte records.
+- When summarizing for a human, always mention: Serde adapter layer, header-based mapping, and field-indexed error reporting.
+[END FILE METADATA]
+```

--- a/src/error.metadata.txt
+++ b/src/error.metadata.txt
@@ -1,0 +1,52 @@
+```
+[FILE METADATA]
+high_level_purpose:
+- Defines the error types and formatting used across CSV reading, writing, and Serde integration.
+- Encapsulates position-aware error reporting for parsing, UTF-8 validation, and record-length mismatches.
+
+core_domain_concepts:
+- Error / ErrorKind: top-level error wrapper and detailed variants for I/O, UTF-8, unequal lengths, seek misuse, serialize, and deserialize errors.
+- Utf8Error / FromUtf8Error: structured UTF-8 validation errors with field index and offset context.
+- IntoInnerError: error returned when consuming a `Writer` fails during flush.
+
+correctness_critical_invariants_and_assumptions:
+- Invariant: `Error` is a thin wrapper over `ErrorKind` and uses `ErrorKind::position()` for convenience access.
+- Invariant: `Utf8Error` reports field index and `valid_up_to` within that field, matching per-field validation in record conversion.
+- Assumption: position metadata may be absent (`None`), so callers must handle missing positional context.
+
+lifecycle_and_main_flows:
+- Error creation: constructors in parsing/serialization code wrap specific failures into `ErrorKind` variants.
+- Display flow: `fmt::Display` formats user-readable messages, including position when available.
+- Recovery flow: `FromUtf8Error` retains the original `ByteRecord` for recovery or inspection.
+
+edge_cases_and_tricky_behavior:
+- `ErrorKind::Seek` is a specialized error signaling misuse of header access after seeking; it is not an I/O error.
+- `Error::is_io_error` only checks for `ErrorKind::Io`, which can matter when integrating with generic error handling.
+
+concurrency_and_ordering_contracts:
+- None; logic is effectively single-threaded and synchronous.
+
+error_propagation_and_recovery:
+- `Error` implements conversions to/from `io::Error`, enabling integration with standard I/O APIs.
+- `IntoInnerError` preserves the original writer for recovery after a failed flush.
+- `Deserialize` errors wrap underlying Serde failures and carry optional position metadata.
+
+design_and_responsibility_boundaries:
+- This module centralizes error taxonomy; other modules should only construct `ErrorKind` and not duplicate formatting logic.
+- UTF-8 errors are distinct from general I/O errors to allow precise user feedback and recovery paths.
+
+likely_bug_hotspots_and_risks:
+- Risk: inconsistent use of position metadata across modules can produce confusing error messages.
+- Risk: callers treating all errors as I/O may miss CSV-specific context (unequal lengths, UTF-8 errors).
+
+refactoring_and_extension_notes:
+- `ErrorKind` is `#[non_exhaustive]`; new variants should preserve backward compatibility and formatting expectations.
+- Maintain the separation between `Utf8Error` (validation) and `FromUtf8Error` (conversion with record context).
+
+usage_guidance_for_future_llms:
+- For code review, focus on: accurate error variant selection and inclusion of position metadata.
+- For architectural review, consider: whether new error types should extend `ErrorKind` or be wrapped separately.
+- For adding new features, pay particular attention to: ensuring new errors preserve diagnostics and recovery options.
+- When summarizing for a human, always mention: the main error variants and the availability of position-aware diagnostics.
+[END FILE METADATA]
+```

--- a/src/lib.metadata.txt
+++ b/src/lib.metadata.txt
@@ -1,0 +1,50 @@
+```
+[FILE METADATA]
+high_level_purpose:
+- Defines the crate’s public surface (re-exports and module wiring) plus small configuration enums for CSV parsing/writing behavior.
+- Provides the `invalid_option` Serde helper to intentionally treat invalid, non-empty fields as `None` instead of errors.
+
+core_domain_concepts:
+- QuoteStyle: high-level quoting policy used by writers, mapped to `csv_core` quote behavior.
+- Terminator: record terminator policy (CRLF vs an explicit byte) used by readers/writers.
+- Trim: whitespace trimming policy for headers and/or fields in readers.
+- invalid_option: custom deserializer helper that converts invalid `Option<T>` values into `None`.
+
+correctness_critical_invariants_and_assumptions:
+- Invariant: `Trim` variants explicitly control whether headers, fields, or both are trimmed; callers rely on these for consistent parsing semantics.
+- Invariant: `Terminator::CRLF` treats `\r`, `\n`, and `\r\n` as a single terminator, while `Any` uses the provided byte literally.
+- Assumption: users who opt into `invalid_option` accept silent data loss for non-empty invalid fields.
+
+lifecycle_and_main_flows:
+- Configuration flow: enums (QuoteStyle/Terminator/Trim) are chosen at build time and converted to `csv_core` equivalents during reader/writer construction.
+- Deserialization flow: `invalid_option` defers to `Option<T>` deserialization and coerces any error into `None`.
+
+edge_cases_and_tricky_behavior:
+- `invalid_option` suppresses all parsing errors for non-empty invalid fields, which can mask data quality issues.
+- `Trim` only governs whitespace removal; it does not affect other parsing behaviors (e.g., delimiter handling).
+
+concurrency_and_ordering_contracts:
+- None; logic is effectively single-threaded and synchronous.
+
+error_propagation_and_recovery:
+- `invalid_option` deliberately converts deserialization errors into `Ok(None)` instead of propagating them.
+
+design_and_responsibility_boundaries:
+- This module centralizes public API exposure (re-exports) and lightweight configuration enums, leaving heavy parsing/serialization logic to submodules.
+- `invalid_option` is an explicit opt-in extension point for tolerant parsing.
+
+likely_bug_hotspots_and_risks:
+- Risk: misuse of `invalid_option` can hide malformed data and complicate debugging.
+- Risk: misunderstanding of `Trim` semantics (headers vs fields) can lead to subtle data mismatches.
+
+refactoring_and_extension_notes:
+- `#[non_exhaustive]` enums signal planned extensibility; new variants must remain backward compatible for public API.
+- The module’s role as a façade means changes here can have wide API impact; prefer additive changes.
+
+usage_guidance_for_future_llms:
+- For code review, focus on: correctness of enum-to-core mappings and the intentional error suppression in `invalid_option`.
+- For architectural review, consider: whether new configuration knobs belong here or in submodules.
+- For adding new features, pay particular attention to: maintaining `non_exhaustive` compatibility and documenting behavior changes.
+- When summarizing for a human, always mention: the crate-level configuration enums and the `invalid_option` behavior.
+[END FILE METADATA]
+```

--- a/src/reader.metadata.txt
+++ b/src/reader.metadata.txt
@@ -1,0 +1,58 @@
+```
+[FILE METADATA]
+high_level_purpose:
+- Implements CSV reading and parsing, including builder configuration, header handling, trimming, and Serde deserialization iterators.
+- Bridges `csv_core` parsing with higher-level `StringRecord`/`ByteRecord` APIs and position-aware error reporting.
+
+core_domain_concepts:
+- ReaderBuilder: configuration for delimiters, terminators, header handling, trimming, and flexible record lengths.
+- Reader: buffered parser wrapper that owns parsing state, headers cache, and iteration APIs.
+- Headers: cached header record in both byte and string forms, with optional UTF-8 validation errors.
+- Iterators: record and deserialization iterators (borrowed and owned) that delegate to `read_record`/`read_byte_record`.
+
+correctness_critical_invariants_and_assumptions:
+- Invariant: when `flexible` is false, all records must match the field count of the first record; mismatches yield `ErrorKind::UnequalLengths`.
+- Invariant: header handling is centralized; when `has_headers` is true, the first record is consumed as headers and not yielded by record iterators.
+- Invariant: trimming rules differ by record type (Unicode for `StringRecord`, ASCII for `ByteRecord`) and are applied according to `Trim` settings.
+- Assumption: callers do not wrap the input in additional buffering; the reader manages buffering internally.
+
+lifecycle_and_main_flows:
+- Setup: configure a `ReaderBuilder`, then construct a `Reader` from a path or reader.
+- Header flow: headers are lazily read and cached on first access or during initial record reads; callers may also set them explicitly.
+- Record flow: `read_record`/`read_byte_record` pull records, apply trimming, enforce flexibility, and update position tracking.
+- Deserialization flow: `deserialize` iterators reuse the record reading path and pass cached headers for struct/map decoding.
+
+edge_cases_and_tricky_behavior:
+- If `has_headers` is false but headers were read or set manually, the reader can still return headers and may replay them once on the first record read.
+- Calling `headers` or `byte_headers` after seeking before the first record yields `ErrorKind::Seek`.
+- When trimming headers, invalid UTF-8 in headers yields an error for string headers while byte headers remain accessible.
+- Reading headers on empty input returns an empty record rather than an error.
+
+concurrency_and_ordering_contracts:
+- None; logic is effectively single-threaded and synchronous.
+
+error_propagation_and_recovery:
+- I/O and parsing errors surface directly; record-length mismatches raise `ErrorKind::UnequalLengths` unless `flexible` is enabled.
+- UTF-8 errors arise when converting byte headers or records into string records; byte access remains possible.
+- Serde deserialization errors are wrapped with record positions and propagated through iterators.
+
+design_and_responsibility_boundaries:
+- `Reader` owns parsing state and header caching; `csv_core` handles low-level CSV parsing.
+- `StringRecord` and `ByteRecord` encapsulate record storage/validation; reader coordinates trimming and position metadata.
+- Iterators are thin adapters over `read_record`/`read_byte_record` to keep behavior consistent.
+
+likely_bug_hotspots_and_risks:
+- Risk: header caching and trimming interactions (especially with invalid UTF-8) can lead to subtle mismatches between byte and string header views.
+- Risk: flexible vs non-flexible record-length enforcement depends on stateful tracking and can be error-prone when seeking.
+
+refactoring_and_extension_notes:
+- Preserve the lazy header read semantics; many APIs rely on headers being available both before and after iteration.
+- Any changes to trimming should keep the ASCII-vs-Unicode distinction intact to avoid breaking existing behavior.
+
+usage_guidance_for_future_llms:
+- For code review, focus on: header caching logic, trimming application points, and unequal-length error handling.
+- For architectural review, consider: separation of concerns between parsing (`csv_core`) and record validation/normalization.
+- For adding new features, pay particular attention to: how new options interact with header caching and iterator behavior.
+- When summarizing for a human, always mention: configuration builder, header handling, and flexible record-length enforcement.
+[END FILE METADATA]
+```

--- a/src/serializer.metadata.txt
+++ b/src/serializer.metadata.txt
@@ -1,0 +1,52 @@
+```
+[FILE METADATA]
+high_level_purpose:
+- Implements Serde serialization from Rust values into CSV records using the crate’s `Writer`.
+- Provides a companion header serializer that derives header rows from struct field names with explicit state-machine rules.
+
+core_domain_concepts:
+- SeRecord: Serde `Serializer` that writes scalar values as CSV fields and flattens containers.
+- SeHeader: Serde `Serializer` that inspects a value for field names and writes header rows when appropriate.
+- HeaderState: state machine that enforces which serializer shapes are allowed when writing headers.
+
+correctness_critical_invariants_and_assumptions:
+- Invariant: record serialization writes fields in traversal order; nested containers are flattened depth-first.
+- Invariant: `serialize_none` and `serialize_unit` emit empty fields to preserve column count.
+- Assumption: header serialization only writes field names for struct-like data; other shapes should not trigger headers.
+
+lifecycle_and_main_flows:
+- Record flow: `serialize` instantiates `SeRecord` and delegates to Serde to write each field to the `Writer`.
+- Header flow: `serialize_header` runs `SeHeader`, which may write field names and returns whether headers were written.
+- State transitions: `SeHeader` enforces ordering rules (scalars/containers inside or outside struct fields) to prevent ambiguous header generation.
+
+edge_cases_and_tricky_behavior:
+- `SeHeader` rejects certain shapes (e.g., scalars after struct fields or containers inside struct fields) with explicit errors, based on the state machine.
+- Header writing for enums and variants depends on whether they expose field names; non-struct variants do not generate headers.
+- Byte and string fields are serialized as-is; no UTF-8 validation is performed for byte slices.
+
+concurrency_and_ordering_contracts:
+- None; logic is effectively single-threaded and synchronous.
+
+error_propagation_and_recovery:
+- Serialization errors are converted to `ErrorKind::Serialize` with descriptive messages for invalid shapes or unsupported operations.
+- The serializer propagates writer errors directly through `Writer::write_field` calls.
+
+design_and_responsibility_boundaries:
+- This module is the Serde boundary for writing; it delegates buffering and CSV formatting to `Writer`.
+- Header generation logic is isolated in `SeHeader`, making it an extension point for header behavior changes.
+
+likely_bug_hotspots_and_risks:
+- Risk: the header state machine is subtle; changes can break expectations about when headers are written or errors occur.
+- Risk: flattening nested containers can surprise callers expecting nested data to map to structured CSV columns.
+
+refactoring_and_extension_notes:
+- Preserve the `HeaderState` transitions and error rules; they encode API-visible behavior.
+- Any new serialization shapes or header rules should be reflected consistently between `SeRecord` and `SeHeader`.
+
+usage_guidance_for_future_llms:
+- For code review, focus on: header state transitions, field flattening order, and error mapping.
+- For architectural review, consider: whether new header policies should be separate configuration options rather than serializer logic.
+- For adding new features, pay particular attention to: how Serde container shapes map to CSV columns and header generation rules.
+- When summarizing for a human, always mention: Serde serialization, flattening behavior, and header state-machine constraints.
+[END FILE METADATA]
+```

--- a/src/string_record.metadata.txt
+++ b/src/string_record.metadata.txt
@@ -1,0 +1,52 @@
+```
+[FILE METADATA]
+high_level_purpose:
+- Implements `StringRecord`, a UTF-8–validated CSV row type built on top of `ByteRecord`.
+- Provides safe conversions between byte and string records, trimming, iteration, and Serde deserialization for string-oriented workflows.
+
+core_domain_concepts:
+- StringRecord: UTF-8–validated record wrapper over `ByteRecord`.
+- FromUtf8Error: error that preserves the original `ByteRecord` and validation details.
+- Reader integration: internal `read` helper that fills a `StringRecord` from a `Reader` with UTF-8 validation.
+
+correctness_critical_invariants_and_assumptions:
+- Invariant: all fields in a `StringRecord` are valid UTF-8; methods like `get` and iteration assume this.
+- Invariant: `read` clears the underlying `ByteRecord` if UTF-8 validation fails, preventing invalid UTF-8 from persisting in a `StringRecord`.
+- Assumption: callers selecting `StringRecord` accept UTF-8 validation costs and failures for invalid data.
+
+lifecycle_and_main_flows:
+- Construction flow: create empty records, push fields, or convert from `ByteRecord` with validation.
+- Reader flow: `read` pulls a byte record from a `Reader`, validates UTF-8, and returns EOF/position-aware results.
+- Conversion flow: `from_byte_record_lossy` replaces invalid sequences with U+FFFD, yielding a usable `StringRecord`.
+
+edge_cases_and_tricky_behavior:
+- `from_byte_record_lossy` performs a lossy replacement for invalid UTF-8, which may mask data issues.
+- `trim` uses Unicode whitespace semantics (unlike `ByteRecord`, which uses ASCII), which can lead to differing behavior between record types.
+
+concurrency_and_ordering_contracts:
+- None; logic is effectively single-threaded and synchronous.
+
+error_propagation_and_recovery:
+- `from_byte_record` returns `FromUtf8Error` with the original record for recovery.
+- `read` returns `ErrorKind::Utf8` with the original reader position on UTF-8 validation failure.
+- Serde deserialization errors are surfaced via `deserialize_string_record` with optional position metadata.
+
+design_and_responsibility_boundaries:
+- This module focuses on UTF-8 safety and record ergonomics; parsing mechanics live in the reader and byte-level logic in `ByteRecord`.
+- Conversion APIs (`from_byte_record`, `into_byte_record`) are key boundaries for data validation and error capture.
+
+likely_bug_hotspots_and_risks:
+- Risk: assuming UTF-8 validity in downstream code can lead to panics if `StringRecord` invariants are violated by unsafe changes.
+- Risk: lossy conversions may be misused where strict validation is required.
+
+refactoring_and_extension_notes:
+- Preserve the invariant that `StringRecord` never contains invalid UTF-8, especially in `read` and conversion paths.
+- Any new trimming or transformation APIs should clarify Unicode vs ASCII behavior.
+
+usage_guidance_for_future_llms:
+- For code review, focus on: UTF-8 validation paths, `read` safety guarantees, and trimming semantics.
+- For architectural review, consider: whether new data-tolerant behaviors belong here or in `ByteRecord`/reader APIs.
+- For adding new features, pay particular attention to: maintaining UTF-8 invariants and error propagation with position metadata.
+- When summarizing for a human, always mention: UTF-8 guarantees, conversion options (strict vs lossy), and reader integration.
+[END FILE METADATA]
+```

--- a/src/tutorial.metadata.txt
+++ b/src/tutorial.metadata.txt
@@ -1,0 +1,42 @@
+```
+[FILE METADATA]
+high_level_purpose:
+- Provides an in-depth tutorial for using the CSV crate, covering reading, writing, headers, Serde, and configuration.
+- Acts as narrative onboarding material for users new to the crate and to CSV parsing in Rust.
+
+core_domain_concepts:
+- Usage patterns: reader/writer construction, record iteration, deserialization/serialization, and configuration knobs.
+- CSV semantics guidance: headers, delimiters, trimming, and error handling expectations in examples.
+
+correctness_critical_invariants_and_assumptions:
+- Assumption: tutorial examples and explanations stay aligned with actual API behavior and defaults.
+- Invariant: documented defaults (e.g., header handling and delimiters) must match code to avoid user confusion.
+
+lifecycle_and_main_flows:
+- Documentation flow: sequential tutorial sections that build from basic reading to advanced Serde and configuration usage.
+
+edge_cases_and_tricky_behavior:
+- Tutorial highlights behavior differences (e.g., headers vs no headers) to prevent misinterpretation of record iteration results.
+
+concurrency_and_ordering_contracts:
+- None; documentation only.
+
+error_propagation_and_recovery:
+- Examples demonstrate propagating errors via `Result` and handling failures in `main`.
+
+design_and_responsibility_boundaries:
+- This module is purely documentation and does not contain runtime logic; it should mirror public API behavior.
+
+likely_bug_hotspots_and_risks:
+- Risk: documentation drift when API defaults or behaviors change can mislead users.
+
+refactoring_and_extension_notes:
+- When adding new features or changing defaults, update the tutorial to keep examples and explanations accurate.
+
+usage_guidance_for_future_llms:
+- For code review, focus on: correctness of the narrative and example alignment with API behavior.
+- For architectural review, consider: whether new features require tutorial coverage to support onboarding.
+- For adding new features, pay particular attention to: updating tutorial sections that describe defaults or core workflows.
+- When summarizing for a human, always mention: this is the main user-facing tutorial with step-by-step examples.
+[END FILE METADATA]
+```

--- a/src/writer.metadata.txt
+++ b/src/writer.metadata.txt
@@ -1,0 +1,56 @@
+```
+[FILE METADATA]
+high_level_purpose:
+- Implements CSV writing with configurable formatting, buffering, header generation, and Serde-based serialization.
+- Bridges `csv_core` output with higher-level `Writer` APIs and record-length enforcement.
+
+core_domain_concepts:
+- WriterBuilder: configuration for delimiter, terminator, quote style, flexibility, and header writing.
+- Writer: buffered writer that tracks header state, field counts, and record serialization.
+- HeaderState: state machine controlling whether headers are written via Serde serialization.
+- Buffer: internal byte buffer required by `csv_core` write APIs.
+
+correctness_critical_invariants_and_assumptions:
+- Invariant: when `flexible` is false, record field counts must match the first record; mismatches yield `ErrorKind::UnequalLengths`.
+- Invariant: `HeaderState` ensures headers are written at most once and only when enabled.
+- Invariant: `fields_written` resets per record and is compared against `first_field_count` for length checks.
+- Assumption: callers should not wrap the output in their own buffering; `Writer` manages buffering and flushing.
+
+lifecycle_and_main_flows:
+- Setup: configure `WriterBuilder`, build a `Writer` from a path or writer.
+- Write flow: `write_record` and `write_field` feed fields to `csv_core`, flushing the internal buffer as needed.
+- Serialize flow: `serialize` uses Serde to write fields and optional headers; header writing happens before the first serialized record.
+- Finalization flow: `flush` writes buffered bytes to the underlying writer; `into_inner` flushes and returns the inner writer or `IntoInnerError`.
+
+edge_cases_and_tricky_behavior:
+- Dropping a `Writer` triggers a flush unless it is already in a panicked state; write errors during drop are ignored.
+- `write_field` can be mixed with `write_record`, but callers must ensure record boundaries align to avoid unexpected field counts.
+- Header writing only occurs through Serde serialization; manual `write_record` calls do not auto-generate headers.
+
+concurrency_and_ordering_contracts:
+- None; logic is effectively single-threaded and synchronous.
+
+error_propagation_and_recovery:
+- I/O failures from flushing propagate as `io::Error` or `IntoInnerError` when consuming the writer.
+- Unequal record lengths raise `ErrorKind::UnequalLengths` unless `flexible` is enabled.
+- Serialization errors are wrapped as `ErrorKind::Serialize` and surfaced by `serialize`.
+
+design_and_responsibility_boundaries:
+- `Writer` handles buffering and state (headers, field counts), while `csv_core` performs low-level CSV formatting.
+- Serde-specific header logic is delegated to the `serializer` module.
+
+likely_bug_hotspots_and_risks:
+- Risk: interactions between `write_field` and `write_record` can accidentally desynchronize record boundaries.
+- Risk: header state transitions combined with serialization errors can lead to partial output (headers written but record fails).
+
+refactoring_and_extension_notes:
+- Preserve the `HeaderState` semantics and field-count tracking; these are user-visible behavioral contracts.
+- Any changes to buffering must respect `csv_core`’s requirement for mutable output slices.
+
+usage_guidance_for_future_llms:
+- For code review, focus on: record-length enforcement, header state transitions, and flush behavior.
+- For architectural review, consider: how builder options map to `csv_core` settings and writer state.
+- For adding new features, pay particular attention to: header handling and interactions with `serialize`.
+- When summarizing for a human, always mention: configurable writer behavior, header handling, and record-length enforcement.
+[END FILE METADATA]
+```


### PR DESCRIPTION
### Motivation
- Provide compact, orthogonal LLM-friendly semantic metadata for the crate's primary source modules to speed future model queries about behavior, invariants, and risks.
- Follow the repository allowlist rules and the provided prompt to create/update metadata for each allowlisted Rust source and skip short files.

### Description
- Added metadata stubs `src/*.metadata.txt` for the allowlisted modules: `byte_record`, `string_record`, `reader`, `writer`, `deserializer`, `serializer`, `error`, `lib`, `cookbook`, and `tutorial`, each following the required `[FILE METADATA]` structure and focusing on invariants, edge cases, contracts, and risks.
- Updated `.github/metadata/allowlist.txt` to document the skipped short source file: `src/debug.rs` (files < 100 lines are intentionally omitted and recorded in the allowlist comments).
- Metadata generation followed the mapping `a.rs -> a.metadata.txt` and the rules from the prompt: create when missing and treat existing metadata as modified (here these are new stubs that summarize the expensive-to-derive semantics of the corresponding source files).
- Committed the new files and the allowlist update to the repository.

### Testing
- No automated tests were executed for these metadata-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69688060a01883308d0a0607a02d9bf8)