### PR TITLE
Revert "Add retain for records" — restore previous trim behavior

### DIFF
--- a/src/byte_record.rs
+++ b/src/byte_record.rs
@@ -409,60 +409,14 @@ impl ByteRecord {
         if length == 0 {
             return;
         }
-        let mut write = 0;
-        let mut prev_end = 0;
-        for i in 0..length {
-            let end = self.0.bounds.ends[i];
-            let start = prev_end;
-            prev_end = end;
-            let (trim_start, trim_end) =
-                trim_ascii_range(&self.0.fields[start..end]);
-            let trimmed_start = start + trim_start;
-            let trimmed_end = start + trim_end;
-            self.0.fields.copy_within(trimmed_start..trimmed_end, write);
-            write += trimmed_end - trimmed_start;
-            self.0.bounds.ends[i] = write;
+        // TODO: We could likely do this in place, but for now, we allocate.
+        let mut trimmed =
+            ByteRecord::with_capacity(self.as_slice().len(), self.len());
+        trimmed.set_position(self.position().cloned());
+        for field in self.iter() {
+            trimmed.push_field(trim_ascii(field));
         }
-    }
-
-    /// Retain only the fields specified by the predicate.
-    ///
-    /// The predicate is applied in field order, and only fields for which the
-    /// predicate returns true are kept.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use csv::ByteRecord;
-    ///
-    /// let mut record = ByteRecord::from(vec!["a", "", "b", ""]);
-    /// record.retain(|field| !field.is_empty());
-    /// assert_eq!(record, vec!["a", "b"]);
-    /// ```
-    pub fn retain<F>(&mut self, mut keep: F)
-    where
-        F: FnMut(&[u8]) -> bool,
-    {
-        let length = self.len();
-        if length == 0 {
-            return;
-        }
-        let mut write = 0;
-        let mut prev_end = 0;
-        let mut kept = 0;
-        for i in 0..length {
-            let end = self.0.bounds.ends[i];
-            let start = prev_end;
-            prev_end = end;
-            let field = &self.0.fields[start..end];
-            if keep(field) {
-                self.0.fields.copy_within(start..end, write);
-                write += end - start;
-                self.0.bounds.ends[kept] = write;
-                kept += 1;
-            }
-        }
-        self.0.bounds.len = kept;
+        *self = trimmed;
     }
 
     /// Add a new field to this record.
@@ -941,12 +895,8 @@ impl<'r> DoubleEndedIterator for ByteRecordIter<'r> {
     }
 }
 
-fn trim_ascii_range(bytes: &[u8]) -> (usize, usize) {
-    let trimmed_start = trim_ascii_start(bytes);
-    let start = bytes.len() - trimmed_start.len();
-    let trimmed = trim_ascii_end(trimmed_start);
-    let end = start + trimmed.len();
-    (start, end)
+fn trim_ascii(bytes: &[u8]) -> &[u8] {
+    trim_ascii_start(trim_ascii_end(bytes))
 }
 
 fn trim_ascii_start(mut bytes: &[u8]) -> &[u8] {
@@ -1115,16 +1065,6 @@ mod tests {
         let mut rec = ByteRecord::new();
         rec.trim();
         assert_eq!(rec.as_slice().len(), 0);
-    }
-
-    #[test]
-    fn retain_fields() {
-        let mut rec = ByteRecord::from(vec!["a", "", "b", "", "c"]);
-        rec.retain(|field| !field.is_empty());
-        assert_eq!(rec, vec!["a", "b", "c"]);
-
-        rec.retain(|field| field == b"b");
-        assert_eq!(rec, vec!["b"]);
     }
 
     #[test]

--- a/src/string_record.rs
+++ b/src/string_record.rs
@@ -450,46 +450,14 @@ impl StringRecord {
         if length == 0 {
             return;
         }
-        let mut write = 0;
-        let mut prev_end = 0;
-        let (fields, ends) = self.0.as_parts();
-        for i in 0..length {
-            let end = ends[i];
-            let start = prev_end;
-            prev_end = end;
-            let field =
-                unsafe { str::from_utf8_unchecked(&fields[start..end]) };
-            let (trim_start, trim_end) = trim_unicode_range(field);
-            let trimmed_start = start + trim_start;
-            let trimmed_end = start + trim_end;
-            fields.copy_within(trimmed_start..trimmed_end, write);
-            write += trimmed_end - trimmed_start;
-            ends[i] = write;
+        // TODO: We could likely do this in place, but for now, we allocate.
+        let mut trimmed =
+            StringRecord::with_capacity(self.as_slice().len(), self.len());
+        trimmed.set_position(self.position().cloned());
+        for field in &*self {
+            trimmed.push_field(field.trim());
         }
-    }
-
-    /// Retain only the fields specified by the predicate.
-    ///
-    /// The predicate is applied in field order, and only fields for which the
-    /// predicate returns true are kept.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use csv::StringRecord;
-    ///
-    /// let mut record = StringRecord::from(vec!["a", "", "b", ""]);
-    /// record.retain(|field| !field.is_empty());
-    /// assert_eq!(record, vec!["a", "b"]);
-    /// ```
-    pub fn retain<F>(&mut self, mut keep: F)
-    where
-        F: FnMut(&str) -> bool,
-    {
-        self.0.retain(|field| {
-            let field = unsafe { str::from_utf8_unchecked(field) };
-            keep(field)
-        });
+        *self = trimmed;
     }
 
     /// Add a new field to this record.
@@ -796,14 +764,6 @@ impl<'r> DoubleEndedIterator for StringRecordIter<'r> {
     }
 }
 
-fn trim_unicode_range(field: &str) -> (usize, usize) {
-    let trimmed_start = field.trim_start();
-    let start = field.len() - trimmed_start.len();
-    let trimmed = trimmed_start.trim_end();
-    let end = start + trimmed.len();
-    (start, end)
-}
-
 #[cfg(test)]
 mod tests {
     use crate::field_mask::FieldMask;
@@ -903,15 +863,7 @@ mod tests {
         let keep_none = FieldMask::from_predicate(rec.len(), |_| false);
         rec.apply_mask(&keep_none);
         assert!(rec.is_empty());
-    fn retain_fields() {
-        let mut rec = StringRecord::from(vec!["a", "", "b", "", "c"]);
-        rec.retain(|field| !field.is_empty());
-        assert_eq!(rec, vec!["a", "b", "c"]);
-
-        rec.retain(|field| field == "b");
-        assert_eq!(rec, vec!["b"]);
     }
-
     // Check that record equality respects field boundaries.
     //
     // Regression test for #138.


### PR DESCRIPTION
### Motivation
- Undo the change that introduced in-place trimming and new `retain` APIs so the library uses the previous allocation-based `trim` implementations for record types.
- Keep public surface and behavior consistent by removing the experimental `retain` additions and their tests.

### Description
- Restored allocation-based `trim` implementations in `src/byte_record.rs` and `src/string_record.rs` by using `ByteRecord::with_capacity` and `StringRecord::with_capacity` and preserving the prior `trim_ascii`/`trim` semantics.
- Removed the `retain` methods and the helper functions used for in-place trimming (`trim_ascii_range` and `trim_unicode_range`).
- Reverted the unit-test changes that exercised the `retain` APIs so tests reflect the prior behavior; modified files touched are `src/byte_record.rs` and `src/string_record.rs` only and metadata was not changed.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968c8a6d3f48330aab9973762608eb0)